### PR TITLE
[Sync] Update project files from source repository (1d213f1)

### DIFF
--- a/.github/actions/warm-cache/action.yml
+++ b/.github/actions/warm-cache/action.yml
@@ -267,7 +267,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 📥 Full checkout for module download (module cache miss)
       if: steps.setup-go.outputs.module-cache-hit != 'true'
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
 
@@ -306,7 +306,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 📥 Full checkout for build warming (module hit, build miss)
       if: steps.setup-go.outputs.module-cache-hit == 'true' && steps.setup-go.outputs.build-cache-hit != 'true'
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
 

--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -98,7 +98,7 @@ jobs:
         # empty on pull_request_review, where `github.ref` is refs/pull/<n>/merge (PR-controlled).
         # Read the base branch directly from the event payload so it is the trusted base ref for
         # BOTH triggers. Env files and the action are not modified there, so base-ref loading is safe.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -94,7 +94,7 @@ jobs:
         # write) can never be a PR-controlled version. Default checkout on pull_request
         # events resolves to the PR head. Lower risk here (job is gated to dependabot[bot]),
         # but pinned for defense-in-depth and consistency with the other PR workflows.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false

--- a/.github/workflows/fortress-benchmarks.yml
+++ b/.github/workflows/fortress-benchmarks.yml
@@ -129,7 +129,7 @@ jobs:
       # Checkout code and set up Go environment
       # --------------------------------------------------------------------
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/fortress-code-quality.yml
+++ b/.github/workflows/fortress-code-quality.yml
@@ -80,7 +80,7 @@ jobs:
       # Shared setup
       # --------------------------------------------------------------------
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -449,7 +449,7 @@ jobs:
       # Checkout code (required for local actions)
       # --------------------------------------------------------------------
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/fortress-completion-report.yml
+++ b/.github/workflows/fortress-completion-report.yml
@@ -138,7 +138,7 @@ jobs:
       # Checkout repository for local actions and helper scripts
       # --------------------------------------------------------------------
       - name: 📥 Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/fortress-coverage.yml
+++ b/.github/workflows/fortress-coverage.yml
@@ -153,7 +153,7 @@ jobs:
           echo "✅ Branch helper functions created"
 
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0 # Fetch all history including tags for version display
@@ -2441,7 +2441,7 @@ jobs:
           done
 
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 2 # Need history for codecov to detect changes

--- a/.github/workflows/fortress-pre-commit.yml
+++ b/.github/workflows/fortress-pre-commit.yml
@@ -67,7 +67,7 @@ jobs:
       # Checkout code (full checkout to ensure local actions are available)
       # --------------------------------------------------------------------
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0 # Fetch full history to enable file change detection for all commit ranges

--- a/.github/workflows/fortress-release.yml
+++ b/.github/workflows/fortress-release.yml
@@ -62,7 +62,7 @@ jobs:
       # Checkout code and set up Go environment
       # --------------------------------------------------------------------
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # Required for changelog generation
           token: ${{ secrets.github-token }}

--- a/.github/workflows/fortress-security-scans.yml
+++ b/.github/workflows/fortress-security-scans.yml
@@ -95,7 +95,7 @@ jobs:
       # SHARED SETUP
       # ====================================================================
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0 # Full history required for Gitleaks (other scans tolerate this)

--- a/.github/workflows/fortress-setup-config.yml
+++ b/.github/workflows/fortress-setup-config.yml
@@ -235,7 +235,7 @@ jobs:
       # ENVIRONMENT LOAD
       # ====================================================================
       - name: 📥 Checkout (env loader)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -320,14 +320,14 @@ jobs:
       # --------------------------------------------------------------------
       - name: 📥 Checkout (full - MAGE-X local build)
         if: env.MAGE_X_USE_LOCAL == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: 📥 Checkout (sparse)
         if: env.MAGE_X_USE_LOCAL != 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0 # Required so the magex `metrics:mage` step can read git metadata

--- a/.github/workflows/fortress-test-fuzz.yml
+++ b/.github/workflows/fortress-test-fuzz.yml
@@ -69,7 +69,7 @@ jobs:
       # Checkout code (required for local actions)
       # --------------------------------------------------------------------
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/fortress-test-matrix.yml
+++ b/.github/workflows/fortress-test-matrix.yml
@@ -132,7 +132,7 @@ jobs:
       # Checkout code (required for local actions)
       # --------------------------------------------------------------------
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/fortress-test-suite.yml
+++ b/.github/workflows/fortress-test-suite.yml
@@ -190,7 +190,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/fortress-warm-cache.yml
+++ b/.github/workflows/fortress-warm-cache.yml
@@ -112,13 +112,13 @@ jobs:
       # --------------------------------------------------------------------
       - name: 📥 Checkout code (full - multi-module)
         if: steps.extract.outputs.enable_multi_module == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: 📥 Checkout code (sparse - single module)
         if: steps.extract.outputs.enable_multi_module != 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -147,7 +147,7 @@ jobs:
       # checkov:skip=CKV_GHA_3:Base branch checkout is intentional and safe
       # sonarcloud:S7631 — false positive: base-ref sparse checkout only (see NOSONAR below)
       - name: 📥 Checkout base repo (sparse)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2 — NOSONAR(S7631): base-ref sparse checkout only; PR head is never checked out or executed
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.2 — NOSONAR(S7631): base-ref sparse checkout only; PR head is never checked out or executed
         with:
           persist-credentials: false
           ref: ${{ github.base_ref || github.ref }}
@@ -751,7 +751,7 @@ jobs:
       # checkov:skip=CKV_GHA_3:Base branch checkout is intentional and safe
       # sonarcloud:S7631 — false positive: base-ref sparse checkout only (see NOSONAR below)
       - name: 📥 Checkout base repo (sparse)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2 — NOSONAR(S7631): base-ref sparse checkout only; PR head is never checked out or executed
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.2 — NOSONAR(S7631): base-ref sparse checkout only; PR head is never checked out or executed
         with:
           persist-credentials: false
           ref: ${{ github.base_ref || github.ref }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -65,7 +65,7 @@ jobs:
       # Check out code to access env file
       # --------------------------------------------------------------------
       - name: 📥 Checkout code (sparse)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -67,7 +67,7 @@ jobs:
       # Check out code to access env file
       # --------------------------------------------------------------------
       - name: 📥 Checkout code (sparse)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -138,7 +138,7 @@ jobs:
       # Checkout repository
       # --------------------------------------------------------------------
       - name: 📥 Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 2 # Fetch enough history to check parent commits


### PR DESCRIPTION
## What Changed

* Updated `actions/checkout` action from commit hash `df4cb1c069e1874edd31b4311f1884172cec0e10` (v6.0.3) to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` (v7.0.0) across all GitHub workflow files
* Applied this version bump consistently across 20 workflow and action files, including warm-cache action, security scans, benchmarks, code quality, release workflows, and other CI automation
* All checkout action usages maintain the same configuration (`persist-credentials: false` and appropriate `fetch-depth` where specified)

## Why It Was Necessary

* Updating to v7.0.0 of the checkout action ensures the project uses the latest stable version with security fixes and improvements
* Keeping dependencies up-to-date across all workflow files reduces security vulnerabilities and ensures consistent behavior
* Standardizing on a single version across all 20 files prevents potential inconsistencies in checkout behavior between different workflows

## Testing Performed

* Verify that all GitHub Actions workflows continue to execute successfully with the updated checkout action version
* Confirm that checkout operations complete as expected in workflows with different checkout configurations (shallow vs full history)
* Monitor workflow runs for any behavioral changes or failures related to the repository checkout step

## Impact / Risk

* **Low risk** - This is a dependency version update for a widely-used, stable GitHub Action maintained by GitHub
* **No breaking changes expected** - The configuration parameters used (`persist-credentials`, `fetch-depth`) remain compatible with v7.0.0
* **Potential benefit** - May include performance improvements, bug fixes, or security enhancements from the checkout action update

<!-- go-broadcast-metadata
group:
  id: mrz-sdks
  name: mrz-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 20
  files_with_original_content: 20
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 1d213f1dab2effb1f2bbe23bad3eed23b9afeba0
  target_repo: mrz1836/go-mail
  sync_commit: aff9e58d11312e85969375b362f46feda9fab4f1
  sync_time: 2026-06-23T09:26:56-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 329
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 699
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 272
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 427
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 189
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 574
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 19
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 867
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 478
performance:
  total_files: 103
-->
